### PR TITLE
Use arm64 buid on m1 macs

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -12,9 +12,9 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 
 declare extension=""
 case "$OSTYPE" in
-  CYGWIN*|MINGW32_NT*|MSYS*|Windows*|msys*)
-    extension=".exe"
-    ;;
+CYGWIN* | MINGW32_NT* | MSYS* | Windows* | msys*)
+  extension=".exe"
+  ;;
 esac
 
 # TODO: Adapt this to proper extension and adapt extracting strategy.
@@ -23,4 +23,4 @@ release_file="${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}${extension:-}"
 # Download to the download directory
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-chmod a+x ${release_file}
+chmod a+x "${release_file}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -50,55 +50,58 @@ download_release() {
   # shellcheck disable=SC2155
   local target="${ASDF_WEBSOCAT_DISTRO:-}"
 
-  if [[ -z "${target}" ]] ; then
+  if [[ -z "${target}" ]]; then
     # https://doc.rust-lang.org/nightly/rustc/platform-support.html
     case "$uname_m" in
-      aarch64)
-        case "$uname_s" in
-          Android) target="websocat.aarch64-linux-android" ;;
-          Darwin)
-            # Use x86_64 until native aarch64 binary released
-            target="websocat.x86_64-apple-darwin" ;;
-          Linux) target="websocat.aarch64-unknown-linux-musl" ;;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
+    aarch64)
+      case "$uname_s" in
+      Android) target="websocat.aarch64-linux-android" ;;
+      Darwin)
+        # Use x86_64 until native aarch64 binary released
+        target="websocat.x86_64-apple-darwin"
         ;;
-      armv7*)
-        case "$uname_s" in
-          Android) target="websocat.armv7-linux-androideabi" ;;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
+      Linux) target="websocat.aarch64-unknown-linux-musl" ;;
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    armv7*)
+      case "$uname_s" in
+      Android) target="websocat.armv7-linux-androideabi" ;;
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    arm64)
+      case "$uname_s" in
+      Darwin) target="websocat.aarch64-apple-darwin" ;;
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    arm*)
+      case "$uname_s" in
+      Linux) target="websocat.arm-unknown-linux-musleabi" ;;
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    i?86)
+      case "$uname_s" in
+      CYGWIN* | MINGW32_NT* | MSYS* | Windows*)
+        target="websocat.i686-pc-windows-gnu.exe"
         ;;
-      arm64)
-        case "$uname_s" in
-          Darwin) target="websocat.aarch64-apple-darwin" ;;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    x86_64)
+      case "$uname_s" in
+      Darwin) target="websocat.x86_64-apple-darwin" ;;
+      FreeBSD) target="websocat.x86_64-unknown-freebsd" ;;
+      Linux) target="websocat.x86_64-unknown-linux-musl" ;;
+      CYGWIN* | MINGW32_NT* | MSYS* | Windows*)
+        target="websocat.x86_64-pc-windows-gnu.exe"
         ;;
-      arm*)
-        case "$uname_s" in
-          Linux) target="websocat.arm-unknown-linux-musleabi" ;;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
-        ;;
-      i?86)
-        case "$uname_s" in
-          CYGWIN*|MINGW32_NT*|MSYS*|Windows*)
-            target="websocat.i686-pc-windows-gnu.exe";;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
-        ;;
-      x86_64)
-        case "$uname_s" in
-          Darwin) target="websocat.x86_64-apple-darwin" ;;
-          FreeBSD) target="websocat.x86_64-unknown-freebsd" ;;
-          Linux) target="websocat.x86_64-unknown-linux-musl" ;;
-          CYGWIN*|MINGW32_NT*|MSYS*|Windows*)
-            target="websocat.x86_64-pc-windows-gnu.exe" ;;
-          *) fail "OS not supported: $uname_s" ;;
-        esac
-        ;;
-      *) fail "Architecture not supported: $uname_m" ;;
+      *) fail "OS not supported: $uname_s" ;;
+      esac
+      ;;
+    *) fail "Architecture not supported: $uname_m" ;;
     esac
   fi
   url="$GH_REPO/releases/download/v${version}/${target}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -69,6 +69,12 @@ download_release() {
           *) fail "OS not supported: $uname_s" ;;
         esac
         ;;
+      arm64)
+        case "$uname_s" in
+          Darwin) target="websocat.aarch64-apple-darwin" ;;
+          *) fail "OS not supported: $uname_s" ;;
+        esac
+        ;;
       arm*)
         case "$uname_s" in
           Linux) target="websocat.arm-unknown-linux-musleabi" ;;


### PR DESCRIPTION
Hi,

on a m1 mac i currently get `OS not supported: Darwin`.
The hardware platform is called `arm64` .
```
$ uname -m
arm64
```
Rust target architecture is called `aarch64-apple-darwin`
see https://doc.rust-lang.org/nightly/rustc/platform-support.html

The PR is tested locally with [mise](https://mise.jdx.dev/), but it should also work with asdf